### PR TITLE
Update to support Serverless v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x, 15.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+      - run: yarn test

--- a/README.md
+++ b/README.md
@@ -12,13 +12,6 @@ Inject terraform outputs into your Serverless config.
 ```yaml
 service: my-service
 
-provider:
-  name: aws
-  runtime: nodejs12.x
-  apiGateway:
-    restApiId: ${terraformRemoteState.commonInfra.outputs.rest_api.id}
-    restApiRootResourceId: ${terraformRemoteState.commonInfra.outputs.rest_api.root_resource_id}
-
 custom:
   terraformRemoteState:
     commonInfra:
@@ -34,11 +27,18 @@ custom:
         key: state/my-service/tf.state
         region: ap-southeast-2
 
+provider:
+  name: aws
+  runtime: nodejs12.x
+  apiGateway:
+    restApiId: ${terraformRemoteState:commonInfra.outputs.rest_api.id}
+    restApiRootResourceId: ${terraformRemoteState:commonInfra.outputs.rest_api.root_resource_id}
+
 functions:
   snsListener:
     handler: src/sns_listener.handler
     events:
       - sns:
-          arn: ${terraformRemoteState.myService.outputs.my_sns_topic.arn}
+          arn: ${terraformRemoteState:myService.outputs.my_sns_topic.arn}
 
 ```

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ provider:
   name: aws
   runtime: nodejs12.x
   apiGateway:
-    restApiId: ${self:custom.terraformRemoteState.commonInfra.outputs.rest_api.id}
-    restApiRootResourceId: ${self:custom.terraformRemoteState.commonInfra.outputs.rest_api.root_resource_id}
+    restApiId: ${terraformRemoteState.commonInfra.outputs.rest_api.id}
+    restApiRootResourceId: ${terraformRemoteState.commonInfra.outputs.rest_api.root_resource_id}
 
 custom:
   terraformRemoteState:
@@ -35,10 +35,10 @@ custom:
         region: ap-southeast-2
 
 functions:
-  snsListener:  
+  snsListener:
     handler: src/sns_listener.handler
     events:
       - sns:
-          arn: ${self:custom.terraformRemoteState.myService.outputs.my_sns_topic.arn}
+          arn: ${terraformRemoteState.myService.outputs.my_sns_topic.arn}
 
 ```

--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
   "dependencies": {
     "aws-sdk": "^2.835.0",
     "fp-ts": "^2.9.5",
-    "io-ts": "^2.2.14"
+    "io-ts": "^2.2.14",
+    "lodash.get": "^4.4.2"
+  },
+  "peerDependencies": {
+    "serverless": ">=2"
   }
 }

--- a/src/lib/Serverless.d.ts
+++ b/src/lib/Serverless.d.ts
@@ -7,7 +7,7 @@ declare namespace Serverless {
     config: {
       servicePath: string
     }
-
+    configSchemaHandler: { defineCustomProperties: any }
     service: {
       provider: {
         name: string

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,0 +1,23 @@
+const configSchema = {
+  type: 'object',
+  properties: {
+    bucket: { type: 'string' },
+    key: { type: 'string' },
+    region: { type: 'string' },
+  },
+  required: ['bucket', 'key'],
+}
+
+const backendSchema = {
+  type: 'object',
+  properties: {
+    backend: { type: 'string' },
+    config: configSchema,
+  }
+}
+
+export const tfStateSchema = {
+  type: 'object',
+  properties: {},
+  additionalProperties: backendSchema
+}

--- a/src/lib/terraform-remote-state-plugin.ts
+++ b/src/lib/terraform-remote-state-plugin.ts
@@ -17,12 +17,6 @@ export const apply = (serverless: Serverless.Instance, options: Serverless.Optio
           .then(parse)
           .then(r => isRight(r) ? Promise.resolve(r.right) : Promise.reject(r.left))
           .then(r => ({ key: k, output: r }))))
-
-      outputs.forEach(o => {
-        //serverless.service.custom.terraformRemoteState[o.key].outputs = o.output
-        serverless.cli.log('fetched terraform remote state')
-        serverless.cli.log(`terraform remote state ${serverless.service.custom.terraformRemoteState[o.key].outputs}`)
-      })
       return outputs
     } else {
       return Promise.reject(`Bad config: ${JSON.stringify(serverless.service.custom.terraformRemoteState)}. Expected { bucket, key, region}`)

--- a/src/lib/terraform-remote-state-plugin.ts
+++ b/src/lib/terraform-remote-state-plugin.ts
@@ -5,6 +5,8 @@ import { parse } from './state-parser'
 import { fetchers } from './fetchers'
 import * as get from 'lodash/get'
 
+const schemaKey = 'terraformRemoteState'
+
 export const apply = (serverless: Serverless.Instance, options: Serverless.Options, downloaders: typeof fetchers) => async () => {
   if (!serverless.service.custom.terraformRemoteState) {
     return Promise.resolve()
@@ -78,10 +80,9 @@ export class TerraformRemoteStatePlugin {
       'before:offline:start': hookHandler,
       'before:offline:start:init': hookHandler
     }
-    const foo = this;
-    const key = 'terraformRemoteState'
+    const self = this
     this.configurationVariablesSources = {
-       [key]: {
+       [schemaKey]: {
          async resolve({address, params, resolveConfigurationProperty, options}) {
           const data  = await hookHandler()
           const bar = (data || []).reduce((acc,{key,output})=>{
@@ -90,7 +91,7 @@ export class TerraformRemoteStatePlugin {
           },{})
 
 
-          foo.resolvedData = bar
+          self.resolvedData = bar
 
           const result = get(bar, address, null)
           return {

--- a/src/lib/terraform-remote-state-plugin.ts
+++ b/src/lib/terraform-remote-state-plugin.ts
@@ -3,6 +3,7 @@ import { isRight } from 'fp-ts/Either'
 import { PluginConfigCodec } from './config'
 import { parse } from './state-parser'
 import { fetchers } from './fetchers'
+import * as get from 'lodash/get'
 
 export const apply = (serverless: Serverless.Instance, options: Serverless.Options, downloaders: typeof fetchers) => async () => {
   if (!serverless.service.custom.terraformRemoteState) {
@@ -16,7 +17,13 @@ export const apply = (serverless: Serverless.Instance, options: Serverless.Optio
           .then(parse)
           .then(r => isRight(r) ? Promise.resolve(r.right) : Promise.reject(r.left))
           .then(r => ({ key: k, output: r }))))
-      outputs.forEach(o => serverless.service.custom.terraformRemoteState[o.key].outputs = o.output)
+
+      outputs.forEach(o => {
+        //serverless.service.custom.terraformRemoteState[o.key].outputs = o.output
+        serverless.cli.log('fetched terraform remote state')
+        serverless.cli.log(`terraform remote state ${serverless.service.custom.terraformRemoteState[o.key].outputs}`)
+      })
+      return outputs
     } else {
       return Promise.reject(`Bad config: ${JSON.stringify(serverless.service.custom.terraformRemoteState)}. Expected { bucket, key, region}`)
     }
@@ -26,15 +33,79 @@ export const apply = (serverless: Serverless.Instance, options: Serverless.Optio
 export class TerraformRemoteStatePlugin {
   hooks: { [key: string]: Function }
   pluginName: string
+  configurationVariablesSources: any
+  serverless: Serverless.Instance
+  options: Serverless.Options
+  resolvedData: {[key: string]: any}
 
-  constructor(private serverless: Serverless.Instance, private options: Serverless.Options) {
-    const hookHandler = apply(serverless, options, fetchers)
-    this.hooks = {
-      'before:package:initialize': hookHandler,
-      'before:remove:remove': hookHandler,
-      'before:offline:start:init': hookHandler,
-      'before:offline:start': hookHandler,
+  constructor(private serverlessI: Serverless.Instance, private opts: Serverless.Options) {
+    this.serverless = serverlessI
+    this.options = opts
+    this.resolvedData = {}
+    const hookHandler = apply(serverlessI, opts, fetchers)
+    const configSchema = {
+      type: 'object',
+      properties: {
+        bucket: { type: 'string' },
+        key: { type: 'string' },
+        region: { type: 'string' },
+      },
+      required: ['bucket', 'key'],
     }
+
+    const backendSchema = {
+      type: 'object',
+      properties: {
+        backend: { type: 'string' },
+        config: configSchema,
+      }
+    }
+    const newCustomPropSchema = {
+      type: 'object',
+      properties: {},
+      additionalProperties: backendSchema
+    }
+
+    // Attach your piece of schema to main schema
+    this.serverless.configSchemaHandler.defineCustomProperties(newCustomPropSchema)
+
+    this.hooks = {
+      // 'before:aws:common:validate:validate': hookHandler,
+      // 'before:package:initialize': hookHandler,
+      // 'before:package:finalize': hookHandler,
+      // 'after:package:initialize': hookHandler,
+      // 'before:deploy:deploy': hookHandler,
+      // 'before:remove:remove': hookHandler,
+      // 'before:offline:start:init': hookHandler,
+      // 'before:offline:start': hookHandler,
+
+      'before:print:print': hookHandler,
+      'after:package:initialize': hookHandler,
+      'before:offline:start': hookHandler,
+      'before:offline:start:init': hookHandler
+    }
+    const foo = this;
+    const key = 'terraformRemoteState'
+    this.configurationVariablesSources = {
+       [key]: {
+         async resolve({address, params, resolveConfigurationProperty, options}) {
+          const data  = await hookHandler()
+          const bar = (data || []).reduce((acc,{key,output})=>{
+            acc[key]  = {outputs: output}
+            return acc
+          },{})
+
+
+          foo.resolvedData = bar
+
+          const result = get(bar, address, null)
+          return {
+            value: result
+          }
+         },
+       }
+     }
+
     this.pluginName = 'serverless-plugin-terraform-remote-state'
   }
 }

--- a/test/terraform-remote-state-plugin.spec.ts
+++ b/test/terraform-remote-state-plugin.spec.ts
@@ -25,4 +25,3 @@ describe('apply', () => {
         expect(hasOutputs.outputs.api_admin_resource).toEqual(stateJson.outputs.api_admin_resource.value)
     })
 })
-

--- a/test/terraform-remote-state-plugin.spec.ts
+++ b/test/terraform-remote-state-plugin.spec.ts
@@ -19,9 +19,9 @@ describe('apply', () => {
                 }
             }
         }
-        await apply(testConfig as unknown as Serverless.Instance, null as Serverless.Options, { s3: () => () => Promise.resolve(JSON.stringify(stateJson)) })()
-        const hasOutputs: any = testConfig.service.custom.terraformRemoteState.someInfra
-        expect(hasOutputs.outputs.api_v1_resource).toEqual(stateJson.outputs.api_v1_resource.value)
-        expect(hasOutputs.outputs.api_admin_resource).toEqual(stateJson.outputs.api_admin_resource.value)
+        const downloader = { s3: () => () => Promise.resolve(JSON.stringify(stateJson)) }
+        const result = await apply(testConfig as unknown as Serverless.Instance, null as Serverless.Options, downloader)() || []
+
+        expect((result as any).someInfra?.outputs?.api_v1_resource).toEqual(stateJson.outputs.api_v1_resource.value)
     })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
       "target": "es6",
       "sourceMap": true,
       "outDir": "dist",
-      "resolveJsonModule": true
+      "resolveJsonModule": true,
+      "esModuleInterop": true
     },
     "exclude": [
       "node_modules"

--- a/yarn.lock
+++ b/yarn.lock
@@ -546,6 +546,11 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
+"@types/lodash@^4.14.170":
+  version "4.14.170"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.170.tgz#0d67711d4bf7f4ca5147e9091b847479b87925d6"
+  integrity sha512-bpcvu/MKHHeYX+qeEN8GE7DIravODWdACVA1ctevD8CN24RhPZIKMn9ntfAsrvLfSX3cR5RrBKAbYm9bGs0A+Q==
+
 "@types/node@*", "@types/node@^14.14.22":
   version "14.14.22"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.22.tgz#0d29f382472c4ccf3bd96ff0ce47daf5b7b84b18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2434,6 +2434,11 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"


### PR DESCRIPTION
👋 It seems that the current version of the plugin does not support serverless v2. 
This updates the plugin to use the new methods, as described in the documentation